### PR TITLE
Update Azabudai URL

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -29,7 +29,7 @@
   },
   {
     "name": "麻布台",
-    "url": "https://salesforcesaturday-shift.connpass.com/"
+    "url": "https://salesforcesaturday-azabudai.connpass.com/"
   },
   {
     "name": "札幌",


### PR DESCRIPTION
麻布台のURLが404のため現行URLにUpdate