### PR TITLE
fix typo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/paper"]
 	path = themes/paper
-	url = https://github.com/salesforce-saturaday-jp/hugo-template
+	url = https://github.com/salesforce-saturday-jp/hugo-template

--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ theme = "paper"
 
 [params]
   twitter = 'sfsattokyo'
-  github = 'salesforce-saturday-japan'
+  github = 'salesforce-saturday-jp'
   rss = true
   name = 'Salesforce Saturday Japan'
   avatar = 'salesforcesaturdayjapan@gmail.com'


### PR DESCRIPTION
https://salesforce-saturday-jp.github.io/ 上段のgithubアイコンリンクが404だったため該当と思われる箇所を修正しました。
合わせてtypoっぽい箇所があったので修正しました。